### PR TITLE
HB-4906: Fix crash when showing Interstitial and Rewarded ads

### DIFF
--- a/Source/MetaAudienceNetworkAdapterBannerAd.swift
+++ b/Source/MetaAudienceNetworkAdapterBannerAd.swift
@@ -43,7 +43,9 @@ final class MetaAudienceNetworkAdapterBannerAd: MetaAudienceNetworkAdapterAd, Pa
         self.ad = ad
         ad.delegate = self
         ad.frame = CGRect(origin: .zero, size: adSize.size)
-        ad.loadAd(withBidPayload: bidPayload)
+        DispatchQueue.main.async {
+            ad.loadAd(withBidPayload: bidPayload)
+        }
     }
     
     /// Shows a loaded ad.

--- a/Source/MetaAudienceNetworkAdapterInterstitialAd.swift
+++ b/Source/MetaAudienceNetworkAdapterInterstitialAd.swift
@@ -37,7 +37,9 @@ final class MetaAudienceNetworkAdapterInterstitialAd: MetaAudienceNetworkAdapter
         let ad = FBInterstitialAd(placementID: request.partnerPlacement)
         self.ad = ad
         ad.delegate = self
-        ad.load(withBidPayload: bidPayload)
+        DispatchQueue.main.async {
+            ad.load(withBidPayload: bidPayload)
+        }
     }
     
     /// Shows a loaded ad.
@@ -48,9 +50,11 @@ final class MetaAudienceNetworkAdapterInterstitialAd: MetaAudienceNetworkAdapter
         log(.showStarted)
         if let ad = ad {
             if (ad.isAdValid) {
-                ad.show(fromRootViewController: viewController)
-                log(.showSucceeded)
-                completion(.success([:]))
+                DispatchQueue.main.async {
+                    ad.show(fromRootViewController: viewController)
+                    self.log(.showSucceeded)
+                    completion(.success([:]))
+                }
             } else {
                 let error = error(.showFailure, description: "Ad is invalid.")
                 log(.showFailed(error))

--- a/Source/MetaAudienceNetworkAdapterRewardedAd.swift
+++ b/Source/MetaAudienceNetworkAdapterRewardedAd.swift
@@ -37,7 +37,9 @@ final class MetaAudienceNetworkAdapterRewardedAd: MetaAudienceNetworkAdapterAd, 
         let ad = FBRewardedVideoAd(placementID: request.partnerPlacement)
         self.ad = ad
         ad.delegate = self
-        ad.load(withBidPayload: bidPayload)
+        DispatchQueue.main.async {
+            ad.load(withBidPayload: bidPayload)
+        }
     }
     
     /// Shows a loaded ad.
@@ -48,9 +50,11 @@ final class MetaAudienceNetworkAdapterRewardedAd: MetaAudienceNetworkAdapterAd, 
         log(.showStarted)
         if let ad = ad {
             if (ad.isAdValid) {
-                ad.show(fromRootViewController: viewController)
-                log(.showSucceeded)
-                completion(.success([:]))
+                DispatchQueue.main.async {
+                    ad.show(fromRootViewController: viewController)
+                    self.log(.showSucceeded)
+                    completion(.success([:]))
+                }
             } else {
                 let error = error(.showFailure, description: "Ad is invalid.")
                 log(.showFailed(error))


### PR DESCRIPTION
FB's code examples don't say that load() and show() need to be called on the main thread, but show() was crashing until I made this change and there was a long lag when load() was called. Also, XCode showed purple warnings on those methods.

I can't get a fill on the banner placement, but since queuing was necessary for the other load() calls I added it in MetaAudienceNetworkAdapterBannerAd as well.