### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/MetaAudienceNetworkAdapterBannerAd.swift
+++ b/Source/MetaAudienceNetworkAdapterBannerAd.swift
@@ -86,9 +86,8 @@ extension MetaAudienceNetworkAdapterBannerAd: FBAdViewDelegate {
     }
     
     func didFailWithError(adView: FBAdView, partnerError: NSError) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
     

--- a/Source/MetaAudienceNetworkAdapterInterstitialAd.swift
+++ b/Source/MetaAudienceNetworkAdapterInterstitialAd.swift
@@ -77,9 +77,8 @@ extension MetaAudienceNetworkAdapterInterstitialAd: FBInterstitialAdDelegate {
     }
     
     func didFailWithError(interstitialAd: FBInterstitialAd, partnerError: NSError) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
     

--- a/Source/MetaAudienceNetworkAdapterRewardedAd.swift
+++ b/Source/MetaAudienceNetworkAdapterRewardedAd.swift
@@ -77,9 +77,8 @@ extension MetaAudienceNetworkAdapterRewardedAd: FBRewardedVideoAdDelegate {
     }
     
     func didFailWithError(rewardedVideoAd: FBRewardedVideoAd, partnerError: NSError) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
     


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
