### PR TITLE
HB-6737: Add base privacy manifest

### DIFF
--- a/ChartboostMediationAdapterMetaAudienceNetwork.podspec
+++ b/ChartboostMediationAdapterMetaAudienceNetwork.podspec
@@ -10,6 +10,7 @@ Pod::Spec.new do |spec|
   # Source
   spec.module_name  = 'ChartboostMediationAdapterMetaAudienceNetwork'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-meta-audience-network.git', :tag => spec.version }
+  spec.resource_bundles = { 'ChartboostMediationAdapterMetaAudienceNetwork' => ['PrivacyInfo.xcprivacy'] }
   spec.source_files = 'Source/**/*.{swift}'
 
   # Minimum supported versions

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -2,10 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyAccessedAPITypes</key>
-    <array/>
-    <key>NSPrivacyCollectedDataTypes</key>
-    <array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-6737

Though `MetaAudienceNetworkAdapter.swift` imports the `AppTrackingTransparency` framework, the usage in the code does not qualify for any special entries in the manifest.  So therefore, the manifest is bare-bones.

The code I'm referring to is:

```
// Apply App Tracking Transparency setting
// Documentation at: https://developers.facebook.com/docs/app-events/guides/advertising-tracking-enabled
let isTrackingEnabled: Bool
if #available(iOS 14, *) {
    // ATT only available in iOS 14+
    isTrackingEnabled = ATTrackingManager.trackingAuthorizationStatus == .authorized
}
else {
    isTrackingEnabled = ASIdentifierManager.shared().isAdvertisingTrackingEnabled
}
FBAdSettings.setAdvertiserTrackingEnabled(isTrackingEnabled)
```