### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-13
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-13
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-13
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2

--- a/Source/MetaAudienceNetworkAdapter.swift
+++ b/Source/MetaAudienceNetworkAdapter.swift
@@ -60,8 +60,11 @@ final class MetaAudienceNetworkAdapter: PartnerAdapter {
         FBAdSettings.setAdvertiserTrackingEnabled(isTrackingEnabled)
         log(.privacyUpdated(setting: "advertiserTrackingEnabled", value: isTrackingEnabled))
         
-        let settings = FBAdInitSettings(placementIDs: [], mediationService: "Chartboost")
-        
+        let settings = FBAdInitSettings(
+            placementIDs: MetaAudienceNetworkAdapterConfiguration.placementIDs,
+            mediationService: "Chartboost"
+        )
+
         FBAudienceNetworkAds.initialize(with: settings) { result in
             if (result.isSuccess) {
                 self.log(.setUpSucceded)

--- a/Source/MetaAudienceNetworkAdapter.swift
+++ b/Source/MetaAudienceNetworkAdapter.swift
@@ -14,19 +14,27 @@ import UIKit
 final class MetaAudienceNetworkAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
-    let partnerSDKVersion = FB_AD_SDK_VERSION
-    
+    var partnerSDKVersion: String {
+        MetaAudienceNetworkAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.6.15.0.0"
-    
+    var adapterVersion: String {
+        MetaAudienceNetworkAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "facebook"
-    
+    var partnerID: String {
+        MetaAudienceNetworkAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Meta Audience Network"
-    
+    var partnerDisplayName: String {
+        MetaAudienceNetworkAdapterConfiguration.partnerDisplayName
+    }
+
     /// The designated initializer for the adapter.
     /// Chartboost Mediation SDK will use this constructor to create instances of conforming types.
     /// - parameter storage: An object that exposes storage managed by the Chartboost Mediation SDK to the adapter.

--- a/Source/MetaAudienceNetworkAdapterConfiguration.swift
+++ b/Source/MetaAudienceNetworkAdapterConfiguration.swift
@@ -10,6 +10,22 @@ import os.log
 /// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
 @objc public class MetaAudienceNetworkAdapterConfiguration: NSObject {
 
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        FB_AD_SDK_VERSION
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.6.15.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "facebook"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Meta Audience Network"
+
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.facebook", category: "Configuration")
 
     /// Flag that can optionally be set to enable Meta Audience Network's test mode. Make sure to disable test mode in production.

--- a/Source/MetaAudienceNetworkAdapterConfiguration.swift
+++ b/Source/MetaAudienceNetworkAdapterConfiguration.swift
@@ -28,6 +28,14 @@ import os.log
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.facebook", category: "Configuration")
 
+    /// Optional list of placement IDs to pass into Meta Audience Network's initialization settings.
+    /// Empty by default.
+    @objc public static var placementIDs: [String] = [] {
+        didSet {
+            os_log(.debug, log: log, "Meta Audience Network SDK placement IDs set to %{public}s", "\(placementIDs)")
+        }
+    }
+
     /// Flag that can optionally be set to enable Meta Audience Network's test mode. Make sure to disable test mode in production.
     /// Disabled by default.
     @objc public static var testMode: Bool = false {

--- a/Source/MetaAudienceNetworkAdapterConfiguration.swift
+++ b/Source/MetaAudienceNetworkAdapterConfiguration.swift
@@ -11,20 +11,20 @@ import os.log
 @objc public class MetaAudienceNetworkAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         FB_AD_SDK_VERSION
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.6.15.0.0"
+    @objc public static let adapterVersion = "4.6.15.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "facebook"
+    @objc public static let partnerID = "facebook"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Meta Audience Network"
+    @objc public static let partnerDisplayName = "Meta Audience Network"
 
     private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.facebook", category: "Configuration")
 


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.