### PR TITLE
HB-7607: Replace duplicated code with call to helper method

### DIFF
--- a/Source/MetaAudienceNetworkAdapterBannerAd.swift
+++ b/Source/MetaAudienceNetworkAdapterBannerAd.swift
@@ -34,7 +34,8 @@ final class MetaAudienceNetworkAdapterBannerAd: MetaAudienceNetworkAdapterAd, Pa
         // Fail if we cannot fit a fixed size banner in the requested size.
         guard 
             let requestedSize = request.bannerSize,
-            let fittingSize = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize)
+            let fittingSize = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize),
+            let fbSize = fittingSize.fbAdSize
         else {
             let error = error(.loadFailureInvalidBannerSize)
             log(.loadFailed(error))
@@ -46,12 +47,12 @@ final class MetaAudienceNetworkAdapterBannerAd: MetaAudienceNetworkAdapterAd, Pa
 
         let ad = FBAdView(
             placementID: request.partnerPlacement,
-            adSize: fittingSize.fbAdSize,
+            adSize: fbSize,
             rootViewController: viewController
         )
         self.ad = ad
         ad.delegate = self
-        ad.frame = CGRect(origin: .zero, size: fittingSize.fbAdSize.size)
+        ad.frame = CGRect(origin: .zero, size: fbSize.size)
         DispatchQueue.main.async {
             ad.loadAd(withBidPayload: bidPayload)
         }
@@ -86,7 +87,7 @@ extension MetaAudienceNetworkAdapterBannerAd: FBAdViewDelegate {
 }
 
 extension BannerSize {
-    fileprivate var fbAdSize: FBAdSize {
+    fileprivate var fbAdSize: FBAdSize? {
         switch self {
         case .standard:
             kFBAdSizeHeight50Banner
@@ -95,7 +96,7 @@ extension BannerSize {
         case .leaderboard:
             kFBAdSizeHeight90Banner
         default:
-            kFBAdSizeHeight50Banner
+            nil
         }
     }
 }

--- a/Source/MetaAudienceNetworkAdapterBannerAd.swift
+++ b/Source/MetaAudienceNetworkAdapterBannerAd.swift
@@ -85,23 +85,27 @@ extension MetaAudienceNetworkAdapterBannerAd: FBAdViewDelegate {
 // MARK: - Helpers
 extension MetaAudienceNetworkAdapterBannerAd {
     private func fixedBannerSize(for requestedSize: BannerSize?) -> (size: CGSize, partnerSize: FBAdSize)? {
+        // Return a default value if no size is specified
         guard let requestedSize else {
-            return (IABStandardAdSize, kFBAdSizeHeight50Banner)
+            return (BannerSize.standard.size, kFBAdSizeHeight50Banner)
         }
-        let sizes: [(size: CGSize, partnerSize: FBAdSize)] = [
-            (size: IABLeaderboardAdSize, partnerSize: kFBAdSizeHeight90Banner),
-            (size: IABMediumAdSize, partnerSize: kFBAdSizeHeight250Rectangle),
-            (size: IABStandardAdSize, partnerSize: kFBAdSizeHeight50Banner)
-        ]
-        // Find the largest size that can fit in the requested size.
-        for (size, partnerSize) in sizes {
-            // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.size.width >= size.width &&
-                (size.height == 0 || requestedSize.size.height >= size.height) {
-                return (size, partnerSize)
+        // If we can find a size that fits, return that.
+        if let size = BannerSize.largestStandardFixedSizeThatFits(in: requestedSize) {
+            switch size {
+            case .standard:
+                return (BannerSize.standard.size, kFBAdSizeHeight50Banner)
+            case .medium:
+                return (BannerSize.medium.size, kFBAdSizeHeight250Rectangle)
+            case .leaderboard:
+                return (BannerSize.leaderboard.size, kFBAdSizeHeight90Banner)
+            default:
+                // largestStandardFixedSizeThatFits currently only returns .standard, .medium, or .leaderboard,
+                // but if that changes then just default to .standard until this code gets updated.
+                return (BannerSize.standard.size, kFBAdSizeHeight50Banner)
             }
+        } else {
+            // largestStandardFixedSizeThatFits has returned nil to indicate it couldn't find a fit.
+            return nil
         }
-        // The requested size cannot fit any fixed size banners.
-        return nil
     }
 }


### PR DESCRIPTION
Many adapters have similar code for finding the largest standard banner size that will fit within requested dimensions. This can now be replaced with BannerSize.largestStandardFixedSizeThatFits(in:)